### PR TITLE
Change the way the body is read and passed to the Post request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@
 
 # Ignore Gradle build output directory
 build
+
+# Ignore development application properties
+.idea
+.vscode

--- a/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
+++ b/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
@@ -123,6 +123,7 @@ public class HTTPProduceRequestDataTransformer implements ProduceRequestDataTran
         // read the record.value as a byte buffer
         ByteBuffer bodyByteBuffer = record.value();
         log.trace("{}: bodyByteBuffer {}", transformerName, LogUtils.toString(bodyByteBuffer));
+
 //        byte[] bodyArray = bodyByteBuffer.array();
 //        int offset = bodyByteBuffer.arrayOffset();
 //        int length = bodyArray.length - offset;

--- a/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
+++ b/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
@@ -124,6 +124,7 @@ public class HTTPProduceRequestDataTransformer implements ProduceRequestDataTran
         byte[] bodyArray = bodyByteBuffer.array();
         int offset = bodyByteBuffer.arrayOffset();
         int length = bodyArray.length - offset;
+        log.trace("{}: LENGTH {}", transformerName, length);
         httpRequestBuilder.POST(HttpRequest.BodyPublishers.ofByteArray(bodyArray, offset, length));
 
         HttpRequest httpRequest = httpRequestBuilder.build();

--- a/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
+++ b/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
@@ -122,7 +122,7 @@ public class HTTPProduceRequestDataTransformer implements ProduceRequestDataTran
 
         // read the record.value as a byte buffer
         ByteBuffer bodyByteBuffer = record.value();
-        log.trace("{}: bodyByteBuffer {}", transformerName, LogUtils.toString(bodyByteBuffer));
+//        log.trace("{}: bodyByteBuffer {}", transformerName, LogUtils.toString(bodyByteBuffer));
 
 //        byte[] bodyArray = bodyByteBuffer.array();
 //        int offset = bodyByteBuffer.arrayOffset();
@@ -146,7 +146,7 @@ public class HTTPProduceRequestDataTransformer implements ProduceRequestDataTran
         //transfer the bytes from the buffer to the array
         bodyByteBuffer.get(bodyArray, 0, length);  // Correctly extract the intended value
 
-        log.trace("{}: bodyByteBuffer {}", transformerName, LogUtils.toString(bodyByteBuffer));
+//        log.trace("{}: bodyByteBuffer {}", transformerName, LogUtils.toString(bodyByteBuffer));
 
         // create a POST request with the body array
         httpRequestBuilder.POST(HttpRequest.BodyPublishers.ofByteArray(bodyArray, 0, length));

--- a/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
+++ b/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
@@ -121,11 +121,24 @@ public class HTTPProduceRequestDataTransformer implements ProduceRequestDataTran
         }
 
         ByteBuffer bodyByteBuffer = record.value();
-        byte[] bodyArray = bodyByteBuffer.array();
-        int offset = bodyByteBuffer.arrayOffset();
-        int length = bodyArray.length - offset;
+        log.trace("{}: bodyByteBuffer {}", transformerName, LogUtils.toString(bodyByteBuffer));
+//        byte[] bodyArray = bodyByteBuffer.array();
+//        int offset = bodyByteBuffer.arrayOffset();
+//        int length = bodyArray.length - offset;
+//        log.trace("{}: LENGTH {}", transformerName, length);
+//        httpRequestBuilder.POST(HttpRequest.BodyPublishers.ofByteArray(bodyArray, offset, length));
+
+
+//        int offset = bodyByteBuffer.position();
+        int length = bodyByteBuffer.remaining();  // Correctly set the length to the remaining bytes in the buffer
+        byte[] bodyArray = new byte[length];
         log.trace("{}: LENGTH {}", transformerName, length);
-        httpRequestBuilder.POST(HttpRequest.BodyPublishers.ofByteArray(bodyArray, offset, length));
+
+        bodyByteBuffer.get(bodyArray, 0, length);  // Correctly extract the intended value
+
+        log.trace("{}: bodyByteBuffer {}", transformerName, LogUtils.toString(bodyByteBuffer));
+
+        httpRequestBuilder.POST(HttpRequest.BodyPublishers.ofByteArray(bodyArray, 0, length));
 
         HttpRequest httpRequest = httpRequestBuilder.build();
         log.trace("{}: httpRequest {}", transformerName, httpRequest);

--- a/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
+++ b/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
@@ -130,6 +130,8 @@ public class HTTPProduceRequestDataTransformer implements ProduceRequestDataTran
 
 
 //        int offset = bodyByteBuffer.position();
+        //why is the length always 0?
+        bodyByteBuffer.rewind();
         int length = bodyByteBuffer.remaining();  // Correctly set the length to the remaining bytes in the buffer
         byte[] bodyArray = new byte[length];
         log.trace("{}: LENGTH {}", transformerName, length);

--- a/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
+++ b/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
@@ -120,6 +120,7 @@ public class HTTPProduceRequestDataTransformer implements ProduceRequestDataTran
             httpRequestBuilder.header(header.key(), LogUtils.toString(header.value()));
         }
 
+        // read the record.value as a byte buffer
         ByteBuffer bodyByteBuffer = record.value();
         log.trace("{}: bodyByteBuffer {}", transformerName, LogUtils.toString(bodyByteBuffer));
 //        byte[] bodyArray = bodyByteBuffer.array();
@@ -130,16 +131,23 @@ public class HTTPProduceRequestDataTransformer implements ProduceRequestDataTran
 
 
 //        int offset = bodyByteBuffer.position();
-        //why is the length always 0?
+
+        // rewind the buffer to the beginning
         bodyByteBuffer.rewind();
-        int length = bodyByteBuffer.remaining();  // Correctly set the length to the remaining bytes in the buffer
+
+        //get the number remaining bytes in the buffer
+        int length = bodyByteBuffer.remaining();
+
+        //create a byte array of the same length
         byte[] bodyArray = new byte[length];
         log.trace("{}: bodyByteBuffer length {}", transformerName, length);
 
+        //transfer the bytes from the buffer to the array
         bodyByteBuffer.get(bodyArray, 0, length);  // Correctly extract the intended value
 
         log.trace("{}: bodyByteBuffer {}", transformerName, LogUtils.toString(bodyByteBuffer));
 
+        // create a POST request with the body array
         httpRequestBuilder.POST(HttpRequest.BodyPublishers.ofByteArray(bodyArray, 0, length));
 
         HttpRequest httpRequest = httpRequestBuilder.build();

--- a/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
+++ b/lib/src/main/java/org/apache/kafka/common/requests/transform/HTTPProduceRequestDataTransformer.java
@@ -134,7 +134,7 @@ public class HTTPProduceRequestDataTransformer implements ProduceRequestDataTran
         bodyByteBuffer.rewind();
         int length = bodyByteBuffer.remaining();  // Correctly set the length to the remaining bytes in the buffer
         byte[] bodyArray = new byte[length];
-        log.trace("{}: LENGTH {}", transformerName, length);
+        log.trace("{}: bodyByteBuffer length {}", transformerName, length);
 
         bodyByteBuffer.get(bodyArray, 0, length);  // Correctly extract the intended value
 


### PR DESCRIPTION
There was a problem with the way the value was being converted and passed into the POST request.

Previously it was creating a body that not only contained the actual value BUT is also contained the headers, so when the API received the body as RAW data it was not only the content of the message.

This was proven because with a message of only 4 characters "AAAA" the body length was 49 bytes instead of 4.  Now it only has a length of 4.